### PR TITLE
[BUG] Crashing Reconnection.swift await try! Task.sleep

### DIFF
--- a/Sources/Pawns/Sources/API/Utilities/Reconnection.swift
+++ b/Sources/Pawns/Sources/API/Utilities/Reconnection.swift
@@ -16,10 +16,14 @@ internal class Reconnection: NSObject {
         return AsyncStream { [unowned self] continuation in
                 
             self.timerTask = Task { [unowned self] in
-                await try! Task.sleep(nanoseconds: self.deadline)
-                guard !Task.isCancelled else { return }
-                continuation.yield(())
-                self.stop()
+                do {
+                    await try Task.sleep(nanoseconds: self.deadline)
+                    guard !Task.isCancelled else { return }
+                    continuation.yield(())
+                    self.stop()
+                } catch {
+                    self.stop()
+                }
             }
             
             continuation.onTermination = { _ in continuation.finish() }

--- a/Sources/Pawns/Sources/API/Utilities/Reconnection.swift
+++ b/Sources/Pawns/Sources/API/Utilities/Reconnection.swift
@@ -3,7 +3,7 @@ import Foundation
 internal class Reconnection: NSObject {
     
     private var timerTask: Task<(), Never>? = nil
-    private let deadline: UInt64 = 3_000_000_000
+    private let deadline: UInt64 = 30_000_000_000
 
     internal override init() { /* - */ }
     
@@ -17,7 +17,7 @@ internal class Reconnection: NSObject {
                 
             self.timerTask = Task { [unowned self] in
                 do {
-                    await try Task.sleep(nanoseconds: self.deadline)
+                    await try! Task.sleep(nanoseconds: self.deadline)
                     guard !Task.isCancelled else { return }
                     continuation.yield(())
                     self.stop()


### PR DESCRIPTION
- Wrapped Reconnection.swift await try Task.sleep(...) in to do-catch block.
- Increased sleep duration for reconnection attempt from 3 to 30 seconds.